### PR TITLE
workaround for sdk bug CMS-3011

### DIFF
--- a/packages/data/src/model-list/model-list.ts
+++ b/packages/data/src/model-list/model-list.ts
@@ -65,7 +65,7 @@ export class ModelList extends ResourceList<ModelResource> {
       this.resolveDatamanager()
       .then((datamanager) => {
         this.datamanager = datamanager;
-        return this.datamanager.modelList(this.getFilterOptions(this.config));
+        return this.datamanager.modelList(Object.assign(this.getFilterOptions(this.config), { dataManagerID: this.datamanager.dataManagerID}));
       }).then((list) => {
         this.use(list);
       }).catch((err) => {


### PR DESCRIPTION
when putting a Data Manager object into the model list, the SDK makes a request without dataManagerID. Until this is fixed in ec.sdk (CMS-3011), this workaround explicitly sets the dataManagerID as filter.