### PR TITLE
make config of ModelList overwritable

### DIFF
--- a/packages/data/src/model-list/model-list.ts
+++ b/packages/data/src/model-list/model-list.ts
@@ -12,7 +12,7 @@ export class ModelList extends ResourceList<ModelResource> {
   private datamanager: DataManagerResource | string;
 
   constructor(datamanager: DataManagerResource | string, config: ListConfig<ModelResource>, sdk: SdkService) {
-    super(Object.assign(config, {
+    super(Object.assign({
       identifier: 'modelID',
       onSave: (item, value) => {
         const model = item.getBody();
@@ -48,7 +48,7 @@ export class ModelList extends ResourceList<ModelResource> {
           form: false
         }
       }
-    }), sdk);
+    }, config), sdk);
     this.datamanager = datamanager;
     this.sdk.ready.then(() => {
       this.load();


### PR DESCRIPTION
Currently the modelList is not customizable. When explicitly setting a config with fields, those get overwritten because `Object.assign()` does no deep-assign. If we switch the arguments around, we can either take the default field configuration or set a whole new one, which is way more practical.